### PR TITLE
feat(core): LogSink telemetry abstraction for shared business logic

### DIFF
--- a/packages/podcast_core/lib/providers/audio_player_provider.dart
+++ b/packages/podcast_core/lib/providers/audio_player_provider.dart
@@ -63,10 +63,6 @@ class AudioPlayerPod extends _$AudioPlayerPod {
 
   @override
   Future<Episode?> build() async {
-    // Assign the (synchronous) log sink BEFORE the first `await` so a notifier
-    // method invoked between build() suspending and resuming cannot read an
-    // unassigned `late _logSink` (LateInitializationError). `logSinkProvider`
-    // is synchronous, so this is safe; `watch` keeps it reactive.
     _logSink = ref.watch(logSinkProvider);
     try {
       _player = await ref.watch(_audioServicePodProvider.future);

--- a/packages/podcast_core/lib/providers/audio_player_provider.dart
+++ b/packages/podcast_core/lib/providers/audio_player_provider.dart
@@ -63,6 +63,10 @@ class AudioPlayerPod extends _$AudioPlayerPod {
 
   @override
   Future<Episode?> build() async {
+    // Assign the (synchronous) log sink BEFORE the first `await` so a notifier
+    // method invoked between build() suspending and resuming cannot read an
+    // unassigned `late _logSink` (LateInitializationError). `logSinkProvider`
+    // is synchronous, so this is safe; `watch` keeps it reactive.
     _logSink = ref.watch(logSinkProvider);
     try {
       _player = await ref.watch(_audioServicePodProvider.future);

--- a/packages/podcast_core/lib/providers/audio_player_provider.dart
+++ b/packages/podcast_core/lib/providers/audio_player_provider.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart';
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:podcast_core/data/episode.model.dart';
 import 'package:podcast_core/data/episode_with_status.dart';
@@ -10,6 +9,8 @@ import 'package:podcast_core/providers/app_lifecycle_state_provider.dart';
 import 'package:podcast_core/providers/episode_loader_provider.dart';
 import 'package:podcast_core/providers/playlist_pod_provider.dart';
 import 'package:podcast_core/repository.dart';
+import 'package:podcast_core/services/logging/log_sink.dart';
+import 'package:podcast_core/services/logging/log_sink_provider.dart';
 import 'package:podcast_core/services/podcast_audio_handler.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:rxdart/rxdart.dart';
@@ -56,11 +57,13 @@ class _AudioServicePod extends _$AudioServicePod {
 class AudioPlayerPod extends _$AudioPlayerPod {
   late PodcastAudioHandler _player;
   late Repository _repository;
+  late LogSink _logSink;
 
   final _log = Logger('se.lohnn.podcast.AudioPlayerPod');
 
   @override
   Future<Episode?> build() async {
+    _logSink = ref.watch(logSinkProvider);
     try {
       _player = await ref.watch(_audioServicePodProvider.future);
       _repository = await ref.watch(repositoryProvider.future);
@@ -85,8 +88,12 @@ class AudioPlayerPod extends _$AudioPlayerPod {
 
       return future;
     } catch (e, stackTrace) {
-      debugPrint(e.toString());
-      debugPrintStack(stackTrace: stackTrace);
+      _logSink.reportError(
+        e,
+        stackTrace,
+        name: 'AudioPlayerPod',
+        message: 'Audio player build failed',
+      );
       rethrow;
     }
   }
@@ -109,8 +116,13 @@ class AudioPlayerPod extends _$AudioPlayerPod {
         state = const AsyncData(null);
       }
     } catch (e, stackTrace) {
-      debugPrint(e.toString());
-      debugPrintStack(stackTrace: stackTrace);
+      _logSink.reportError(
+        e,
+        stackTrace,
+        name: 'AudioPlayerPod',
+        message: 'updateQueue failed',
+        context: {'queue_length': queue.length},
+      );
       state = AsyncError(e, stackTrace);
       rethrow;
     }

--- a/packages/podcast_core/lib/providers/audio_player_provider.g.dart
+++ b/packages/podcast_core/lib/providers/audio_player_provider.g.dart
@@ -121,7 +121,7 @@ final class AudioPlayerPodProvider
   AudioPlayerPod create() => AudioPlayerPod();
 }
 
-String _$audioPlayerPodHash() => r'f7322591d0eb0a544af454cb90854920424d511f';
+String _$audioPlayerPodHash() => r'f1271289344a283464b80b5f4d785a761d11a198';
 
 abstract class _$AudioPlayerPod extends $AsyncNotifier<Episode?> {
   FutureOr<Episode?> build();

--- a/packages/podcast_core/lib/providers/find_podcast_provider.dart
+++ b/packages/podcast_core/lib/providers/find_podcast_provider.dart
@@ -1,8 +1,9 @@
-import 'package:flutter/foundation.dart';
 import 'package:podcast_core/data/podcast.model.dart';
 import 'package:podcast_core/data/podcast_search.model.dart';
 import 'package:podcast_core/helpers/debouncer.dart';
 import 'package:podcast_core/repository.dart';
+import 'package:podcast_core/services/logging/log_sink.dart';
+import 'package:podcast_core/services/logging/log_sink_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'find_podcast_provider.g.dart';
@@ -11,18 +12,24 @@ part 'find_podcast_provider.g.dart';
 class FindPodcast extends _$FindPodcast {
   final _searchDebouncer = Debouncer.long();
   late Repository _repository;
+  late LogSink _logSink;
   late bool _mounted;
 
   @override
   Future<List<PodcastSearch>> build() async {
     _repository = await ref.watch(repositoryProvider.future);
+    _logSink = ref.watch(logSinkProvider);
     _mounted = true;
     ref.onDispose(() => _mounted = false);
     try {
       return _repository.findPodcasts();
     } catch (e, stackTrace) {
-      debugPrint(e.toString());
-      debugPrintStack(stackTrace: stackTrace);
+      _logSink.reportError(
+        e,
+        stackTrace,
+        name: 'FindPodcast',
+        message: 'Initial findPodcasts failed',
+      );
       rethrow;
     }
   }
@@ -36,8 +43,13 @@ class FindPodcast extends _$FindPodcast {
 
         if (_mounted) state = AsyncData(podcasts);
       } catch (e, stackTrace) {
-        debugPrint(e.toString());
-        debugPrintStack(stackTrace: stackTrace);
+        _logSink.reportError(
+          e,
+          stackTrace,
+          name: 'FindPodcast',
+          message: 'findPodcasts search failed',
+          context: {'search_term': searchTerm},
+        );
 
         if (_mounted) state = AsyncError(e, stackTrace);
       }

--- a/packages/podcast_core/lib/providers/find_podcast_provider.dart
+++ b/packages/podcast_core/lib/providers/find_podcast_provider.dart
@@ -17,8 +17,12 @@ class FindPodcast extends _$FindPodcast {
 
   @override
   Future<List<PodcastSearch>> build() async {
-    _repository = await ref.watch(repositoryProvider.future);
+    // Assign the (synchronous) log sink BEFORE the first `await` so a notifier
+    // method invoked between build() suspending and resuming cannot read an
+    // unassigned `late _logSink` (LateInitializationError). `logSinkProvider`
+    // is synchronous, so this is safe; `watch` keeps it reactive.
     _logSink = ref.watch(logSinkProvider);
+    _repository = await ref.watch(repositoryProvider.future);
     _mounted = true;
     ref.onDispose(() => _mounted = false);
     try {

--- a/packages/podcast_core/lib/providers/find_podcast_provider.dart
+++ b/packages/podcast_core/lib/providers/find_podcast_provider.dart
@@ -17,10 +17,6 @@ class FindPodcast extends _$FindPodcast {
 
   @override
   Future<List<PodcastSearch>> build() async {
-    // Assign the (synchronous) log sink BEFORE the first `await` so a notifier
-    // method invoked between build() suspending and resuming cannot read an
-    // unassigned `late _logSink` (LateInitializationError). `logSinkProvider`
-    // is synchronous, so this is safe; `watch` keeps it reactive.
     _logSink = ref.watch(logSinkProvider);
     _repository = await ref.watch(repositoryProvider.future);
     _mounted = true;

--- a/packages/podcast_core/lib/providers/find_podcast_provider.g.dart
+++ b/packages/podcast_core/lib/providers/find_podcast_provider.g.dart
@@ -33,7 +33,7 @@ final class FindPodcastProvider
   FindPodcast create() => FindPodcast();
 }
 
-String _$findPodcastHash() => r'562d36f31b4818a1fba36220d464e3c7e125d05f';
+String _$findPodcastHash() => r'7e531dc71823cfcf7588cf441af9a7510ac6f668';
 
 abstract class _$FindPodcast extends $AsyncNotifier<List<PodcastSearch>> {
   FutureOr<List<PodcastSearch>> build();

--- a/packages/podcast_core/lib/services/logging/log_sink.dart
+++ b/packages/podcast_core/lib/services/logging/log_sink.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/foundation.dart';
+
+/// Severity of a telemetry event reported through a [LogSink].
+///
+/// Mirrors the well-known levels of `package:logging` so the production app's
+/// adapter can map straight onto its backend buffer, while staying free of any
+/// dependency on a concrete logging backend.
+enum LogLevel {
+  debug,
+  info,
+  warning,
+  error;
+
+  /// Whether this level is at least as severe as [other].
+  bool operator >=(LogLevel other) => index >= other.index;
+}
+
+/// A single structured telemetry event produced by shared business logic.
+///
+/// This is a presentation-agnostic value object (I-069): the core defines the
+/// *shape* of what it wants to report, and each app provides an adapter that
+/// projects it onto a concrete backend (Loki + Crashlytics in production, debug
+/// console / nothing in the OSS app).
+///
+/// [context] holds structured fields — podcast/episode/screen ids, request
+/// ids, etc. — as plain JSON-encodable values, never bare interpolated
+/// strings, so the backend can filter on them.
+@immutable
+class LogEvent {
+  const LogEvent({
+    required this.level,
+    required this.message,
+    this.name,
+    this.error,
+    this.stackTrace,
+    this.context = const {},
+  });
+
+  /// Severity of the event.
+  final LogLevel level;
+
+  /// Human-readable summary of what happened.
+  final String message;
+
+  /// Optional logical source (e.g. the feature or provider name) used as a
+  /// secondary label/field on the backend.
+  final String? name;
+
+  /// The caught error, if this event reports a failure.
+  final Object? error;
+
+  /// Stack trace associated with [error], if any.
+  final StackTrace? stackTrace;
+
+  /// Structured, filterable fields (podcast/episode/screen/request ids, …).
+  ///
+  /// Values must be JSON-encodable. Prefer typed keys over interpolating ids
+  /// into [message] so the backend stays queryable.
+  final Map<String, Object?> context;
+
+  LogEvent copyWith({Map<String, Object?>? context}) => LogEvent(
+    level: level,
+    message: message,
+    name: name,
+    error: error,
+    stackTrace: stackTrace,
+    context: context ?? this.context,
+  );
+}
+
+/// The seam through which shared business logic in `podcast_core` reports
+/// observability events without knowing where they go.
+///
+/// The OSS app injects [NoopLogSink] (or a debug-printing sink); the production
+/// app injects an adapter that fans the event out to the batched Loki buffer
+/// and Firebase Crashlytics. Core code depends only on this interface, so it
+/// stays buildable and unit-testable against a stub sink (I-069).
+///
+/// Implementations MUST be non-throwing: a failure to report telemetry must
+/// never propagate into the business logic that called [log] (don't let the
+/// observer crash the observed).
+abstract interface class LogSink {
+  /// Report a structured event. Must not throw.
+  void log(LogEvent event);
+
+  /// Convenience for reporting a caught error at [LogLevel.error].
+  ///
+  /// Placed on the interface so call sites that previously did
+  /// `catch → debugPrint → rethrow` can switch to
+  /// `catch → sink.reportError(...) → rethrow` and actually reach the backend.
+  void reportError(
+    Object error,
+    StackTrace stackTrace, {
+    String? message,
+    String? name,
+    Map<String, Object?> context = const {},
+  }) {
+    log(
+      LogEvent(
+        level: LogLevel.error,
+        message: message ?? error.toString(),
+        name: name,
+        error: error,
+        stackTrace: stackTrace,
+        context: context,
+      ),
+    );
+  }
+}
+
+/// A [LogSink] that does nothing. The safe default for the OSS app and tests.
+class NoopLogSink implements LogSink {
+  const NoopLogSink();
+
+  @override
+  void log(LogEvent event) {}
+
+  @override
+  void reportError(
+    Object error,
+    StackTrace stackTrace, {
+    String? message,
+    String? name,
+    Map<String, Object?> context = const {},
+  }) {}
+}
+
+/// A [LogSink] that prints to the debug console only. Useful for the OSS app so
+/// a developer running it locally can still see core telemetry, while shipping
+/// nothing anywhere in release builds.
+class DebugPrintLogSink implements LogSink {
+  const DebugPrintLogSink();
+
+  @override
+  void log(LogEvent event) {
+    if (!kDebugMode) return;
+    final name = event.name == null ? '' : '[${event.name}] ';
+    debugPrint('${event.level.name.toUpperCase()} $name${event.message}');
+    if (event.error != null) {
+      debugPrint('  error: ${event.error}');
+    }
+    if (event.stackTrace != null) {
+      debugPrintStack(stackTrace: event.stackTrace);
+    }
+  }
+
+  @override
+  void reportError(
+    Object error,
+    StackTrace stackTrace, {
+    String? message,
+    String? name,
+    Map<String, Object?> context = const {},
+  }) {
+    log(
+      LogEvent(
+        level: LogLevel.error,
+        message: message ?? error.toString(),
+        name: name,
+        error: error,
+        stackTrace: stackTrace,
+        context: context,
+      ),
+    );
+  }
+}

--- a/packages/podcast_core/lib/services/logging/log_sink.dart
+++ b/packages/podcast_core/lib/services/logging/log_sink.dart
@@ -79,15 +79,30 @@ class LogEvent {
 /// Implementations MUST be non-throwing: a failure to report telemetry must
 /// never propagate into the business logic that called [log] (don't let the
 /// observer crash the observed).
-abstract interface class LogSink {
+///
+/// This is an `abstract class` (not an `abstract interface class`) on purpose:
+/// it is both extendable and implementable. Real sinks should `extends LogSink`
+/// so they inherit the shared [reportError] convenience; test stubs may still
+/// `implements LogSink` when they want to satisfy the contract without the base
+/// behaviour.
+abstract class LogSink {
+  const LogSink();
+
   /// Report a structured event. Must not throw.
   void log(LogEvent event);
 
   /// Convenience for reporting a caught error at [LogLevel.error].
   ///
-  /// Placed on the interface so call sites that previously did
-  /// `catch → debugPrint → rethrow` can switch to
-  /// `catch → sink.reportError(...) → rethrow` and actually reach the backend.
+  /// This is shared behaviour: always wrap the error as a [LogLevel.error]
+  /// [LogEvent] and then call [log]. It lives once on the base class so sinks
+  /// don't each reimplement it — they customise *where* events go via [log],
+  /// not by overriding [reportError]. (Under the old `implements` contract Dart
+  /// did not inherit method bodies, so every sink was forced to duplicate this;
+  /// switching to an extendable base removes that duplication.)
+  ///
+  /// Lets call sites that previously did `catch → debugPrint → rethrow` switch
+  /// to `catch → sink.reportError(...) → rethrow` and actually reach the
+  /// backend.
   void reportError(
     Object error,
     StackTrace stackTrace, {
@@ -109,27 +124,18 @@ abstract interface class LogSink {
 }
 
 /// A [LogSink] that does nothing. The safe default for the OSS app and tests.
-class NoopLogSink implements LogSink {
-  const NoopLogSink();
+class NoopLogSink extends LogSink {
+  const NoopLogSink() : super();
 
   @override
   void log(LogEvent event) {}
-
-  @override
-  void reportError(
-    Object error,
-    StackTrace stackTrace, {
-    String? message,
-    String? name,
-    Map<String, Object?> context = const {},
-  }) {}
 }
 
 /// A [LogSink] that prints to the debug console only. Useful for the OSS app so
 /// a developer running it locally can still see core telemetry, while shipping
 /// nothing anywhere in release builds.
-class DebugPrintLogSink implements LogSink {
-  const DebugPrintLogSink();
+class DebugPrintLogSink extends LogSink {
+  const DebugPrintLogSink() : super();
 
   @override
   void log(LogEvent event) {
@@ -139,28 +145,11 @@ class DebugPrintLogSink implements LogSink {
     if (event.error != null) {
       debugPrint('  error: ${event.error}');
     }
+    if (event.context.isNotEmpty) {
+      debugPrint('  context: ${event.context}');
+    }
     if (event.stackTrace != null) {
       debugPrintStack(stackTrace: event.stackTrace);
     }
-  }
-
-  @override
-  void reportError(
-    Object error,
-    StackTrace stackTrace, {
-    String? message,
-    String? name,
-    Map<String, Object?> context = const {},
-  }) {
-    log(
-      LogEvent(
-        level: LogLevel.error,
-        message: message ?? error.toString(),
-        name: name,
-        error: error,
-        stackTrace: stackTrace,
-        context: context,
-      ),
-    );
   }
 }

--- a/packages/podcast_core/lib/services/logging/log_sink.dart
+++ b/packages/podcast_core/lib/services/logging/log_sink.dart
@@ -2,8 +2,8 @@ import 'package:flutter/foundation.dart';
 
 /// Severity of a telemetry event reported through a [LogSink].
 ///
-/// Mirrors the well-known levels of `package:logging` so the production app's
-/// adapter can map straight onto its backend buffer, while staying free of any
+/// Mirrors the well-known levels of `package:logging` so a host app's adapter
+/// can map straight onto its telemetry backend, while staying free of any
 /// dependency on a concrete logging backend.
 enum LogLevel {
   debug,
@@ -19,8 +19,8 @@ enum LogLevel {
 ///
 /// This is a presentation-agnostic value object (I-069): the core defines the
 /// *shape* of what it wants to report, and each app provides an adapter that
-/// projects it onto a concrete backend (Loki + Crashlytics in production, debug
-/// console / nothing in the OSS app).
+/// projects it onto whatever telemetry or logging backend the host app
+/// provides (debug console / nothing in the OSS app).
 ///
 /// [context] holds structured fields — podcast/episode/screen ids, request
 /// ids, etc. — as plain JSON-encodable values, never bare interpolated
@@ -71,10 +71,10 @@ class LogEvent {
 /// The seam through which shared business logic in `podcast_core` reports
 /// observability events without knowing where they go.
 ///
-/// The OSS app injects [NoopLogSink] (or a debug-printing sink); the production
-/// app injects an adapter that fans the event out to the batched Loki buffer
-/// and Firebase Crashlytics. Core code depends only on this interface, so it
-/// stays buildable and unit-testable against a stub sink (I-069).
+/// The OSS app injects [NoopLogSink] (or a debug-printing sink); a host app can
+/// inject an adapter that fans the event out to whatever telemetry or logging
+/// backend it provides. Core code depends only on this interface, so it stays
+/// buildable and unit-testable against a stub sink (I-069).
 ///
 /// Implementations MUST be non-throwing: a failure to report telemetry must
 /// never propagate into the business logic that called [log] (don't let the

--- a/packages/podcast_core/lib/services/logging/log_sink_provider.dart
+++ b/packages/podcast_core/lib/services/logging/log_sink_provider.dart
@@ -1,0 +1,21 @@
+import 'package:podcast_core/services/logging/log_sink.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'log_sink_provider.g.dart';
+
+/// The [LogSink] shared business logic reports through.
+///
+/// Defaults to [NoopLogSink] so the core package and the OSS app build and
+/// behave with no backend logging. The production app overrides this provider
+/// with an adapter that fans events out to the Loki buffer + Crashlytics.
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     logSinkProvider.overrideWithValue(myLokiCrashlyticsSink),
+///   ],
+///   ...
+/// )
+/// ```
+@Riverpod(keepAlive: true)
+LogSink logSink(Ref ref) => const NoopLogSink();

--- a/packages/podcast_core/lib/services/logging/log_sink_provider.dart
+++ b/packages/podcast_core/lib/services/logging/log_sink_provider.dart
@@ -6,13 +6,14 @@ part 'log_sink_provider.g.dart';
 /// The [LogSink] shared business logic reports through.
 ///
 /// Defaults to [NoopLogSink] so the core package and the OSS app build and
-/// behave with no backend logging. The production app overrides this provider
-/// with an adapter that fans events out to the Loki buffer + Crashlytics.
+/// behave with no backend logging. Host apps override this provider with their
+/// own adapter that fans events out to whatever telemetry or logging backend
+/// they provide.
 ///
 /// ```dart
 /// ProviderScope(
 ///   overrides: [
-///     logSinkProvider.overrideWithValue(myLokiCrashlyticsSink),
+///     logSinkProvider.overrideWithValue(myLogSink),
 ///   ],
 ///   ...
 /// )

--- a/packages/podcast_core/lib/services/logging/log_sink_provider.g.dart
+++ b/packages/podcast_core/lib/services/logging/log_sink_provider.g.dart
@@ -1,0 +1,94 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'log_sink_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The [LogSink] shared business logic reports through.
+///
+/// Defaults to [NoopLogSink] so the core package and the OSS app build and
+/// behave with no backend logging. The production app overrides this provider
+/// with an adapter that fans events out to the Loki buffer + Crashlytics.
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     logSinkProvider.overrideWithValue(myLokiCrashlyticsSink),
+///   ],
+///   ...
+/// )
+/// ```
+
+@ProviderFor(logSink)
+const logSinkProvider = LogSinkProvider._();
+
+/// The [LogSink] shared business logic reports through.
+///
+/// Defaults to [NoopLogSink] so the core package and the OSS app build and
+/// behave with no backend logging. The production app overrides this provider
+/// with an adapter that fans events out to the Loki buffer + Crashlytics.
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     logSinkProvider.overrideWithValue(myLokiCrashlyticsSink),
+///   ],
+///   ...
+/// )
+/// ```
+
+final class LogSinkProvider
+    extends $FunctionalProvider<LogSink, LogSink, LogSink>
+    with $Provider<LogSink> {
+  /// The [LogSink] shared business logic reports through.
+  ///
+  /// Defaults to [NoopLogSink] so the core package and the OSS app build and
+  /// behave with no backend logging. The production app overrides this provider
+  /// with an adapter that fans events out to the Loki buffer + Crashlytics.
+  ///
+  /// ```dart
+  /// ProviderScope(
+  ///   overrides: [
+  ///     logSinkProvider.overrideWithValue(myLokiCrashlyticsSink),
+  ///   ],
+  ///   ...
+  /// )
+  /// ```
+  const LogSinkProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'logSinkProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$logSinkHash();
+
+  @$internal
+  @override
+  $ProviderElement<LogSink> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  LogSink create(Ref ref) {
+    return logSink(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(LogSink value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<LogSink>(value),
+    );
+  }
+}
+
+String _$logSinkHash() => r'16fde7d72786fc17a3b716615a708662e25c1506';

--- a/packages/podcast_core/lib/services/logging/log_sink_provider.g.dart
+++ b/packages/podcast_core/lib/services/logging/log_sink_provider.g.dart
@@ -11,13 +11,14 @@ part of 'log_sink_provider.dart';
 /// The [LogSink] shared business logic reports through.
 ///
 /// Defaults to [NoopLogSink] so the core package and the OSS app build and
-/// behave with no backend logging. The production app overrides this provider
-/// with an adapter that fans events out to the Loki buffer + Crashlytics.
+/// behave with no backend logging. Host apps override this provider with their
+/// own adapter that fans events out to whatever telemetry or logging backend
+/// they provide.
 ///
 /// ```dart
 /// ProviderScope(
 ///   overrides: [
-///     logSinkProvider.overrideWithValue(myLokiCrashlyticsSink),
+///     logSinkProvider.overrideWithValue(myLogSink),
 ///   ],
 ///   ...
 /// )
@@ -29,13 +30,14 @@ const logSinkProvider = LogSinkProvider._();
 /// The [LogSink] shared business logic reports through.
 ///
 /// Defaults to [NoopLogSink] so the core package and the OSS app build and
-/// behave with no backend logging. The production app overrides this provider
-/// with an adapter that fans events out to the Loki buffer + Crashlytics.
+/// behave with no backend logging. Host apps override this provider with their
+/// own adapter that fans events out to whatever telemetry or logging backend
+/// they provide.
 ///
 /// ```dart
 /// ProviderScope(
 ///   overrides: [
-///     logSinkProvider.overrideWithValue(myLokiCrashlyticsSink),
+///     logSinkProvider.overrideWithValue(myLogSink),
 ///   ],
 ///   ...
 /// )
@@ -47,13 +49,14 @@ final class LogSinkProvider
   /// The [LogSink] shared business logic reports through.
   ///
   /// Defaults to [NoopLogSink] so the core package and the OSS app build and
-  /// behave with no backend logging. The production app overrides this provider
-  /// with an adapter that fans events out to the Loki buffer + Crashlytics.
+  /// behave with no backend logging. Host apps override this provider with their
+  /// own adapter that fans events out to whatever telemetry or logging backend
+  /// they provide.
   ///
   /// ```dart
   /// ProviderScope(
   ///   overrides: [
-  ///     logSinkProvider.overrideWithValue(myLokiCrashlyticsSink),
+  ///     logSinkProvider.overrideWithValue(myLogSink),
   ///   ],
   ///   ...
   /// )


### PR DESCRIPTION
Part of the PodCase logging-improvement initiative (Stage 2, shared-core half).

Adds a logging/telemetry **sink abstraction** to `podcast_core` so shared business logic can report errors/events through an interface, instead of swallowing them in `catch → debugPrint → rethrow`.

## What's here
- `services/logging/log_sink.dart` — `LogSink` interface + `LogLevel`/`LogEvent` value types; `NoopLogSink` (default) and `DebugPrintLogSink` (OSS) impls. Stub+adapter seam: each app provides its own sink (prod → Loki+Crashlytics; OSS → debug/no-op).
- `services/logging/log_sink_provider.dart` (+ generated) — `logSinkProvider` defaults to `NoopLogSink`; apps override it.
- Routed previously-swallowed errors in `find_podcast_provider.dart` and `audio_player_provider.dart` through `reportError(...)`.

## Notes
- Consumed by the production app via the `git:` dependency — the app's companion PR depends on this commit. **Merge this PR first.**
- `flutter analyze`: 0 errors. Codegen regenerates clean.